### PR TITLE
Add onboarding tests

### DIFF
--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  preset: 'jest-expo',
+  setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(jest-)?react-native|@react-native|@react-native-community|expo|@expo|react-native-reanimated|@expo-google-fonts)/'
+  ],
+  moduleNameMapper: {
+    '\\.(png|jpg|jpeg|svg)$': '<rootDir>/__mocks__/fileMock.js',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -82,7 +82,10 @@
     "patch-package": "^8.0.0",
     "prettier": "^3.5.3",
     "react-native-dotenv": "^3.4.11",
-    "readable-stream": "^4.7.0"
+    "readable-stream": "^4.7.0",
+    "@testing-library/react-native": "^12.1.5",
+    "@testing-library/jest-native": "^5.9.0",
+    "jest-expo": "^49.0.0"
   },
   "lint-staged": {
     "*.{js,jsx}": [

--- a/src/screens/__tests__/OnboardingScreen.test.js
+++ b/src/screens/__tests__/OnboardingScreen.test.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { ActivityIndicator } from 'react-native';
+import OnboardingScreen from '../OnboardingScreen';
+import { AuthContext } from '../../context/AuthContext';
+import { UserContext } from '../../context/UserContext';
+
+jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper');
+
+jest.mock('firebase/auth', () => ({
+  createUserWithEmailAndPassword: jest.fn(),
+}));
+
+jest.mock('firebase/firestore', () => ({
+  doc: jest.fn(() => 'doc'),
+  setDoc: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../../firebase/firebaseClient', () => ({
+  auth: {},
+  db: {},
+}));
+
+describe('OnboardingScreen', () => {
+  const signInMock = jest.fn();
+  const setUserProfileMock = jest.fn();
+
+  const wrapper = ({ children }) => (
+    <AuthContext.Provider value={{ signIn: signInMock }}>
+      <UserContext.Provider value={{ setUserProfile: setUserProfileMock }}>
+        {children}
+      </UserContext.Provider>
+    </AuthContext.Provider>
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('validates required fields', async () => {
+    const { getByText, queryAllByText } = render(<OnboardingScreen />, { wrapper });
+
+    fireEvent.press(getByText('Get Started'));
+
+    expect(getByText('Invalid email address.')).toBeTruthy();
+    expect(getByText('Password must be at least 6 characters.')).toBeTruthy();
+    expect(queryAllByText('This field is required.').length).toBe(2);
+  });
+
+  it('updates selected avatar when pressed', () => {
+    const { getByA11yLabel } = render(<OnboardingScreen />, { wrapper });
+
+    const avatar = getByA11yLabel('Avatar 1');
+    fireEvent.press(avatar);
+
+    expect(getByA11yLabel('Avatar 1')).toHaveAccessibilityState({ selected: true });
+  });
+
+  it('creates a user and signs in on success', async () => {
+    const { createUserWithEmailAndPassword } = require('firebase/auth');
+    const { setDoc } = require('firebase/firestore');
+
+    createUserWithEmailAndPassword.mockResolvedValue({ user: { uid: '123' } });
+
+    const { getByA11yLabel, getByText, queryByType } = render(<OnboardingScreen />, { wrapper });
+
+    fireEvent.changeText(getByA11yLabel('email'), 'test@example.com');
+    fireEvent.changeText(getByA11yLabel('password'), '123456');
+    fireEvent.changeText(getByA11yLabel('username'), 'tester');
+    fireEvent.press(getByText('Strength'));
+
+    fireEvent.press(getByText('Get Started'));
+
+    expect(queryByType(ActivityIndicator)).toBeTruthy();
+
+    await waitFor(() => expect(createUserWithEmailAndPassword).toHaveBeenCalled());
+
+    expect(setDoc).toHaveBeenCalled();
+    expect(setUserProfileMock).toHaveBeenCalled();
+    expect(signInMock).toHaveBeenCalled();
+    expect(queryByType(ActivityIndicator)).toBeNull();
+  });
+
+  it('shows error message when signup fails', async () => {
+    const { createUserWithEmailAndPassword } = require('firebase/auth');
+    createUserWithEmailAndPassword.mockRejectedValue(new Error('Creation failed'));
+
+    const { getByA11yLabel, getByText, queryByText } = render(<OnboardingScreen />, { wrapper });
+
+    fireEvent.changeText(getByA11yLabel('email'), 'test@example.com');
+    fireEvent.changeText(getByA11yLabel('password'), '123456');
+    fireEvent.changeText(getByA11yLabel('username'), 'tester');
+    fireEvent.press(getByText('Strength'));
+
+    fireEvent.press(getByText('Get Started'));
+
+    await waitFor(() => expect(createUserWithEmailAndPassword).toHaveBeenCalled());
+
+    expect(queryByText('Creation failed')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest config and mocks
- write React Native Testing Library tests for OnboardingScreen
- update package.json with testing dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f41e6c70832094cb70aa9c763dc1